### PR TITLE
fix: load games before validation

### DIFF
--- a/bettensor/validator/utils/io/miner_data.py
+++ b/bettensor/validator/utils/io/miner_data.py
@@ -894,6 +894,13 @@ class MinerDataMixin:
                                 'full_pred': pred
                             })
                         
+                        # Grab the game informations
+                        game_ids = list(set([
+                            pred['full_pred']['game_id']
+                            for pred in all_predictions
+                        ]))
+                        self._batch_load_games(game_ids)
+                        
                         # Sort all predictions by timestamp
                         all_predictions.sort(key=lambda x: x['timestamp'])
                         


### PR DESCRIPTION
* Updating `miner_data.py`

# Issues

The last PR addressed an issue where `validate_historical_predictions` removed some valid predictions. However, even after it was merged, a few predictions are still being removed unexpectedly. Here’s what we found.

# Mechanism

During the `validate_historical_predictions` phase, the validator (neuron) is freshly initialized, therefore `self._game_cache` is always empty. Then, during `validate_prediction`, it checks the empty `self._game_cache` and determines that the game does not exist. Thus, the `prediction` is removed due to a failure in `validate_prediction`.

Here is a snippet from `miner_data.py`:

```python
# Game validation
game_id = prediction_data.get('game_id')
game = self._game_cache.get(game_id)
if not game:
    # Try string conversion if numeric
    if isinstance(game_id, (int, float)):
        game = self._game_cache.get(str(game_id))
    # Try numeric conversion if string
    elif isinstance(game_id, str):
        try:
            game = self._game_cache.get(int(game_id))
        except ValueError:
            pass
        
if not game:
    return False, "Game not found in validator game_data", 'game_not_found', -1
```

# Solution

To address this issue, fetch the game information before calling `validate_prediction`:

```python
# Fetch the game information
game_ids = list(set([
    pred['full_pred']['game_id']
    for pred in all_predictions
]))
self._batch_load_games(game_ids)
```